### PR TITLE
Fix cfg syntax errors

### DIFF
--- a/AJEExtended/Parts/Mods/AJEE-AirplanePlus.cfg
+++ b/AJEExtended/Parts/Mods/AJEE-AirplanePlus.cfg
@@ -355,8 +355,8 @@
 	!MODULE[ModuleAlternator],* {}
 	!MODULE[MultiModeEngine] {}
 	
-	!MODULE[ModuleSurfaceFX]:HAS[thrustProviderModuleIndex[2]] {}
-	@MODULE[ModuleSurfaceFX]:HAS[thrustProviderModuleIndex[1]]
+	!MODULE[ModuleSurfaceFX]:HAS[#thrustProviderModuleIndex[2]] {}
+	@MODULE[ModuleSurfaceFX]:HAS[#thrustProviderModuleIndex[1]]
 	{
 		@thrustProviderModuleIndex = 0
 	}
@@ -389,8 +389,8 @@
 	!MODULE[ModuleAlternator],* {}
 	!MODULE[MultiModeEngine] {}
 	
-	!MODULE[ModuleSurfaceFX]:HAS[thrustProviderModuleIndex[2]] {}
-	@MODULE[ModuleSurfaceFX]:HAS[thrustProviderModuleIndex[1]]
+	!MODULE[ModuleSurfaceFX]:HAS[#thrustProviderModuleIndex[2]] {}
+	@MODULE[ModuleSurfaceFX]:HAS[#thrustProviderModuleIndex[1]]
 	{
 		@thrustProviderModuleIndex = 0
 	}

--- a/AJEExtended/Parts/Mods/AJEE-SXT.cfg
+++ b/AJEExtended/Parts/Mods/AJEE-SXT.cfg
@@ -141,8 +141,8 @@
 	!MODULE[ModuleAlternator],* {}
 	!MODULE[MultiModeEngine] {}
 	
-	!MODULE[ModuleSurfaceFX]:HAS[thrustProviderModuleIndex[2]] {}
-	@MODULE[ModuleSurfaceFX]:HAS[thrustProviderModuleIndex[1]]
+	!MODULE[ModuleSurfaceFX]:HAS[#thrustProviderModuleIndex[2]] {}
+	@MODULE[ModuleSurfaceFX]:HAS[#thrustProviderModuleIndex[1]]
 	{
 		@thrustProviderModuleIndex = 0
 	}

--- a/AJEExtended/Parts/Mods/AJEE-Squad.cfg
+++ b/AJEExtended/Parts/Mods/AJEE-Squad.cfg
@@ -96,8 +96,8 @@ AJEE_PART_TEMPLATES
 	!MODULE[ModuleAlternator],* {}
 	!MODULE[MultiModeEngine] {}
 	
-	!MODULE[ModuleSurfaceFX]:HAS[thrustProviderModuleIndex[2]] {}
-	@MODULE[ModuleSurfaceFX]:HAS[thrustProviderModuleIndex[1]]
+	!MODULE[ModuleSurfaceFX]:HAS[#thrustProviderModuleIndex[2]] {}
+	@MODULE[ModuleSurfaceFX]:HAS[#thrustProviderModuleIndex[1]]
 	{
 		@thrustProviderModuleIndex = 0
 	}

--- a/AJEExtended/Parts/Mods/AJEE-Stryker.cfg
+++ b/AJEExtended/Parts/Mods/AJEE-Stryker.cfg
@@ -85,8 +85,8 @@
 	!MODULE[ModuleAlternator],* {}
 	!MODULE[MultiModeEngine] {}
 	
-	!MODULE[ModuleSurfaceFX]:HAS[thrustProviderModuleIndex[2]] {}
-	@MODULE[ModuleSurfaceFX]:HAS[thrustProviderModuleIndex[1]]
+	!MODULE[ModuleSurfaceFX]:HAS[#thrustProviderModuleIndex[2]] {}
+	@MODULE[ModuleSurfaceFX]:HAS[#thrustProviderModuleIndex[1]]
 	{
 		@thrustProviderModuleIndex = 0
 	}
@@ -105,8 +105,8 @@
 	!MODULE[ModuleAlternator],* {}
 	!MODULE[MultiModeEngine] {}
 	
-	!MODULE[ModuleSurfaceFX]:HAS[thrustProviderModuleIndex[2]] {}
-	@MODULE[ModuleSurfaceFX]:HAS[thrustProviderModuleIndex[1]]
+	!MODULE[ModuleSurfaceFX]:HAS[#thrustProviderModuleIndex[2]] {}
+	@MODULE[ModuleSurfaceFX]:HAS[#thrustProviderModuleIndex[1]]
 	{
 		@thrustProviderModuleIndex = 0
 	}
@@ -151,11 +151,11 @@
 	base_diameter = 1.25
 
 	!MODULE[ModuleEngines*],* {}
-	!MODULE[ModuleAlternator],* {
+	!MODULE[ModuleAlternator],* {}
 	!MODULE[MultiModeEngine] {}
 	
-	!MODULE[ModuleSurfaceFX]:HAS[thrustProviderModuleIndex[2]] {}
-	@MODULE[ModuleSurfaceFX]:HAS[thrustProviderModuleIndex[1]]
+	!MODULE[ModuleSurfaceFX]:HAS[#thrustProviderModuleIndex[2]] {}
+	@MODULE[ModuleSurfaceFX]:HAS[#thrustProviderModuleIndex[1]]
 	{
 		@thrustProviderModuleIndex = 0
 	}


### PR DESCRIPTION
Hi @seanyoung247,

I'm using AJEExtended to test some cfg parser code for KSP-CKAN/CKAN#3525, and I found a few minor syntax errors.

This pull request fixes them.

Cheers!
